### PR TITLE
Fix HTTP client timeout to prevent indefinite hangs during API outages

### DIFF
--- a/internal/cscdm/cscdm.go
+++ b/internal/cscdm/cscdm.go
@@ -15,6 +15,7 @@ const (
 	CSC_DOMAIN_MANAGER_API_URL = "https://apis.cscglobal.com/dbs/api/v2/"
 	POLL_INTERVAL              = 5 * time.Second
 	FLUSH_IDLE_DURATION        = 5 * time.Second
+	HTTP_REQUEST_TIMEOUT       = 30 * time.Second
 )
 
 type Client struct {
@@ -36,14 +37,16 @@ type Client struct {
 }
 
 func (c *Client) Configure(apiKey string, apiToken string) {
-	c.http = &http.Client{Transport: &util.HttpTransport{
-		BaseUrl: CSC_DOMAIN_MANAGER_API_URL,
-		Headers: map[string]string{
-			"accept":        "application/json",
-			"apikey":        apiKey,
-			"Authorization": fmt.Sprintf("Bearer %s", apiToken),
-		},
-	}}
+	c.http = &http.Client{
+		Timeout: HTTP_REQUEST_TIMEOUT,
+		Transport: &util.HttpTransport{
+			BaseUrl: CSC_DOMAIN_MANAGER_API_URL,
+			Headers: map[string]string{
+				"accept":        "application/json",
+				"apikey":        apiKey,
+				"Authorization": fmt.Sprintf("Bearer %s", apiToken),
+			},
+		}}
 
 	c.returnChannels = make(map[string]chan *ZoneRecord)
 	c.errorChannels = make(map[string]chan error)


### PR DESCRIPTION
Provider hangs indefinitely when CSC API accepts TCP connections but fails to respond. Retry loops in `createZoneEdit()` and `waitForZoneEdits()` become deadlocked, blocking Terraform operations and CI/CD pipelines.

## Solution

Add 30-second request timeout to HTTP client, **enabling retry logic to recover better from unresponsive API endpoints.**

## Changes

- Add `HTTP_REQUEST_TIMEOUT = 30 * time.Second` constant
- Set `http.Client.Timeout` field in `Configure()` method

## Testing

```bash
# Verify no regression in existing functionality
go test ./internal/cscdm/...

# Test timeout behavior (manual)
# 1. Apply terraform configuration with cscdm_record resource
# 2. Block API responses with: iptables -A OUTPUT -d apis.cscglobal.com -j DROP
# 3. Confirm timeout error after 30 seconds (not indefinite hang)
# 4. Restore: iptables -D OUTPUT -d apis.cscglobal.com -j DROP
```

## Breaking Changes

None. Only changes failure timing from infinite to 30 seconds.